### PR TITLE
upgraded image to version 0.22 and fixed deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-image = "0.21"
+image = "0.22"
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -16,7 +16,7 @@ pub(crate) fn energy_fn<IMG: GenericImageView>(img: &IMG, pos: Pos) -> u32 {
 
 fn square_diff_px<P: Pixel>(p1: P, p2: P) -> u32 {
     let (ch1, ch2) = (p1.channels(), p2.channels());
-    let count = <P as Pixel>::channel_count() as usize;
+    let count = <P as Pixel>::CHANNEL_COUNT as usize;
     let mut sum = 0;
     for i in 0..count {
         sum += square_diff(ch1[i], ch2[i]);


### PR DESCRIPTION
I upgraded the image version to version 0.22, since I want to use seam carving with the functionalities that exists in version 0.22. 

I also fixed some deprecation warnings.